### PR TITLE
Reedline overhaul: vi mode, hint navigation, tab completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.46.0"
-source = "git+https://github.com/mhasse1/reedline.git?branch=main#9c4a49dfc01d31fbf2ba99cbcad97c6365a1ccd2"
+source = "git+https://github.com/mhasse1/reedline.git?branch=main#34e00dc0c20bc4f1cb36e86d7868e1eb8dff24df"
 dependencies = [
  "chrono",
  "crossterm",

--- a/crates/rush-cli/src/repl.rs
+++ b/crates/rush-cli/src/repl.rs
@@ -105,16 +105,28 @@ pub fn run(is_login: bool) {
             .with_style(nu_ansi_term::Style::new().fg(hint_color))
     );
 
+    // Configure external editor for vi 'v' command
+    let buffer_editor_cmd = {
+        let editor_var = std::env::var("VISUAL")
+            .or_else(|_| std::env::var("EDITOR"))
+            .unwrap_or_else(|_| "vi".to_string());
+        std::process::Command::new(editor_var)
+    };
+    let temp_file = std::env::temp_dir().join("rush_edit_buffer.rush");
+
     let mut editor = Reedline::create()
         .with_edit_mode(edit_mode)
         .with_history(Box::new(history))
+        .with_history_exclusion_prefix(Some(" ".to_string()))
         .with_completer(completer)
         .with_hinter(hinter)
         .with_menu(ReedlineMenu::EngineCompleter(completion_menu))
         .with_highlighter(Box::new(RushHighlighter))
         .with_validator(Box::new(RushValidator))
+        .with_buffer_editor(buffer_editor_cmd, temp_file)
         .with_quick_completions(true)
         .with_partial_completions(true)
+        .with_immediate_completions(true)
         .with_ansi_colors(true);
 
     let show_timing = config.show_timing;
@@ -254,10 +266,10 @@ pub fn run(is_login: bool) {
 
                 last_cmd = Some(trimmed.to_string());
 
-                // Flush history before reload --hard (exec replaces process)
-                if trimmed.starts_with("reload") && trimmed.contains("--hard") {
-                    let _ = editor.sync_history();
-                }
+                // Sync history to disk after every command (like bash histappend).
+                // Critical for reload --hard (exec replaces process, no Drop),
+                // but also ensures `history` command reads current state.
+                let _ = editor.sync_history();
 
                 // Execute through unified dispatch
                 let start = std::time::Instant::now();

--- a/crates/rush-core/src/pipeline.rs
+++ b/crates/rush-core/src/pipeline.rs
@@ -223,7 +223,12 @@ fn apply_first(input: Value, args: &[String]) -> Value {
 }
 
 fn apply_last(input: Value, args: &[String]) -> Value {
-    let n: usize = args.first().and_then(|s| s.parse().ok()).unwrap_or(1);
+    let n: usize = args.first()
+        .and_then(|s| {
+            // Handle both "5" and "-5" (Unix tail convention)
+            s.strip_prefix('-').unwrap_or(s).parse().ok()
+        })
+        .unwrap_or(1);
     let items = to_items(input);
     let skip = items.len().saturating_sub(n);
     if n == 1 {


### PR DESCRIPTION
## Summary

Comprehensive reedline fork improvements for vi-mode daily driving, plus Rush-side integration.

### Reedline fork changes (mhasse1/reedline, 7 commits)
- **`v` = OpenEditor** — bash/readline vi behavior (opens $EDITOR with current line)
- **`n`/`N` repeat search** — new NextHistorySearch/PreviousHistorySearch events
- **Esc moves cursor back** — standard vi behavior leaving insert mode
- **Vi hint navigation** — `l` accepts one char, `w` accepts one word, `$` accepts full hint (only at end of buffer)
- **Remove HistoryHintComplete from `l` motion** — was silently accepting hints and corrupting history
- **`$` accepts hint after move** — no double-$ needed after Esc
- **Ctrl+R = Redo in normal mode** — vim behavior (overridable by shell)
- **`with_immediate_completions()` flag** — tab cycling inserts into buffer live, no Enter needed

### Rush-side changes
- Enable immediate_completions, quick_completions, partial_completions
- Configure buffer editor for vi `v` command
- Sync history to disk after every command
- Space-prefix history exclusion
- Alt+/ bindings for fzf in insert mode
- Hint color from theme (contrast-aware)
- `tail -N` argument parsing in pipeline

## Test plan
- [ ] `l`/`w`/`$` navigate into hint text at end of buffer
- [ ] `l` in middle of text just moves right (no hint acceptance)
- [ ] Esc from insert moves cursor back one
- [ ] `v` opens $EDITOR
- [ ] Tab completion inserts first item immediately, cycling works
- [ ] History not corrupted by hint text
- [ ] `reload --hard` preserves history
- [ ] `/pattern` then `n`/`N` repeats search (without fzf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)